### PR TITLE
Fix gather_grass and gather_limestone

### DIFF
--- a/scripts/gather_resources.lua
+++ b/scripts/gather_resources.lua
@@ -41,6 +41,7 @@ function gatherGrass()
 						is_done = 1;
 					end
 			       timeStarted = lsGetTimer()
+             lastGathered = lsGetTimer();
 				end
 			end
 
@@ -72,12 +73,14 @@ end
 
 function gatherLimestone()
 	timeStarted = lsGetTimer();
+	local pos  = srGetWindowSize();
 	while 1 do
 		checkBreak();
 		srReadScreen();
 		local slate = srFindImage("limestone.png",7000);
 			if slate then
 			srClickMouseNoMove(slate[0]+5,slate[1]);
+			srSetMousePos(pos[0]/2, pos[1]/2);
 			sleepWithStatus(2300, "Clicking Limestone Icon\n\nLimestone Collected: " .. tostring(counter) .. "\n\n\nElapsed Time: " .. getElapsedTime(timeStarted));
 			counter = counter + 1;
 			else


### PR DESCRIPTION
Addresses two issues with gather_resources.lua
- If the screen is left on picking coordinate direction for grass gathering for longer then the timeout, the script immediately quits
- Limestone gathering will stop because the mouse is over the icon causing Automato not to detect the icon