### PR TITLE
Updated values for better outcome with long stokes

### DIFF
--- a/scripts/firepits.lua
+++ b/scripts/firepits.lua
@@ -11,7 +11,7 @@ pitlocs = {};
 pitstokecnt = {};
 pitchangecnt = {};
 PIT_THRESH_UNSTOKE = 20;
-PIT_THRESH_STOKE = 4;
+PIT_THRESH_STOKE = 6;
 PIT_TEST_POINTS = 15;
 
 function doit()
@@ -216,7 +216,7 @@ function doStoke(pitnum)
   end
   x,y = srMousePos();
   srSetMousePos(pitlocs[pitnum][0], pitlocs[pitnum][1]);
-  lsSleep(150);
+  lsSleep(200);
   srKeyEvent('S');
   lsSleep(100);
   srSetMousePos(x, y);


### PR DESCRIPTION
A slightly higher threshold and extra delay had 8/9 pits survive a nice 6 hour stoke, where the current values I'm lucky for half to survive that long. Note this change probably won't affect higher end machines but will definitely improve results on lower/mid range laptops.