### PR TITLE
incense_tracker.lua

### DIFF
--- a/scripts/incense_tracker.lua
+++ b/scripts/incense_tracker.lua
@@ -469,6 +469,7 @@ posstats = {
 	["endurance"] = "+End",
 	["speed"] = "+Spd",
 	["strength"] = "+Str",
+	["strenth"] = "+Str", -- This is here due to untrainable OCR characters because of bad font rendering
 }
 
 negstats = {


### PR DESCRIPTION
Workaround for an untrainable "g" due to bad font rendering on the new ATITD client.